### PR TITLE
[util] Clean up socket and endpoint error handling

### DIFF
--- a/arq-benchmark/util/endpoint.cpp
+++ b/arq-benchmark/util/endpoint.cpp
@@ -77,15 +77,15 @@ bool util::Endpoint::connectRetry(std::string_view host,
 }
 
 bool util::Endpoint::accept(std::optional<std::string_view> expectedHost) {
-    try {
-        Socket acceptedSock = socket_.accept(expectedHost);
-        
+    auto acceptedSock = socket_.accept(expectedHost);
+
+    if (acceptedSock.has_value()) {
         // Replace endpoint listening socket with new socket
-        socket_ = std::move(acceptedSock);
+        socket_ = std::move(acceptedSock.value());
         return true;
     }
-    catch (const SocketException& e) {
-        logWarning("failed to accept connection at endpoint ({})", e.what());
+    else {
+        logWarning("failed to accept connection at endpoint");
         return false;
     }
 }

--- a/arq-benchmark/util/endpoint.cpp
+++ b/arq-benchmark/util/endpoint.cpp
@@ -90,28 +90,30 @@ bool util::Endpoint::accept(std::optional<std::string_view> expectedHost) {
     }
 }
 
-bool util::Endpoint::send(std::span<const uint8_t> buffer) const noexcept {
+std::optional<size_t> util::Endpoint::send(std::span<const uint8_t> buffer) const noexcept {
     return socket_.send(buffer);
 }
 
-bool util::Endpoint::recv(std::span<uint8_t> buffer) const noexcept {
+std::optional<size_t> util::Endpoint::recv(std::span<uint8_t> buffer) const noexcept {
     return socket_.recv(buffer);
 }
 
-ssize_t util::Endpoint::sendTo(std::span<const uint8_t> buffer, std::string_view destinationHost, std::string_view destinationService) const noexcept
+std::optional<size_t> util::Endpoint::sendTo(std::span<const uint8_t> buffer, std::string_view destinationHost, std::string_view destinationService) const noexcept
 {
     AddressInfo addr(destinationHost, destinationService, SocketType::UDP);
     for (const auto& ai : addr) {
         auto ret = sendTo(buffer, ai);
-        if (ret > 0) return ret;
+        if (ret.has_value()) {
+            return ret;
+        }
     }
-    return 0; // WJG handle -1...
+    return std::nullopt;
 }
 
-ssize_t util::Endpoint::sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept {
+std::optional<size_t> util::Endpoint::sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept {
     return socket_.sendTo(buffer, ai);
 }
 
-ssize_t util::Endpoint::recvFrom(std::span<uint8_t> buffer) const noexcept {
+std::optional<size_t> util::Endpoint::recvFrom(std::span<uint8_t> buffer) const noexcept {
     return socket_.recvFrom(buffer);
 }

--- a/arq-benchmark/util/endpoint.hpp
+++ b/arq-benchmark/util/endpoint.hpp
@@ -36,13 +36,13 @@ public:
     // the provided argument(s).
     bool accept(std::optional<std::string_view> expectedHost = std::nullopt);
 
-    bool send(std::span<const uint8_t> buffer) const noexcept;
-    bool recv(std::span<uint8_t> buffer) const noexcept;
-    ssize_t sendTo(std::span<const uint8_t> buffer, 
-               std::string_view destinationHost,
-               std::string_view destinationService) const noexcept;
-    ssize_t sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept;
-    ssize_t recvFrom(std::span<uint8_t> buffer) const noexcept;
+    std::optional<size_t> send(std::span<const uint8_t> buffer) const noexcept;
+    std::optional<size_t> recv(std::span<uint8_t> buffer) const noexcept;
+    std::optional<size_t> sendTo(std::span<const uint8_t> buffer, 
+                                 std::string_view destinationHost,
+                                 std::string_view destinationService) const noexcept;
+    std::optional<size_t> sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept;
+    std::optional<size_t> recvFrom(std::span<uint8_t> buffer) const noexcept;
 private:
     // The socket used for communication at this endpoint
     Socket socket_;

--- a/arq-benchmark/util/socket.cpp
+++ b/arq-benchmark/util/socket.cpp
@@ -119,18 +119,26 @@ static auto sockaddr2Str(sockaddr* addr) {
     return Socket{newSocketID};
 }
 
-bool util::Socket::send(std::span<const uint8_t> buffer) const noexcept {
-    return ::send(socketID_, buffer.data(), buffer.size(), 0) != SOCKET_ERROR;
+static inline std::optional<size_t> returnIfNotError(const ssize_t ret) {
+    return ret == SOCKET_ERROR ? std::nullopt : std::make_optional<size_t>(ret);
 }
 
-bool util::Socket::recv(std::span<uint8_t> buffer) const noexcept {
-    return ::recv(socketID_, buffer.data(), buffer.size(), 0) != SOCKET_ERROR;
+std::optional<size_t> util::Socket::send(std::span<const uint8_t> buffer) const noexcept {
+    auto ret = ::send(socketID_, buffer.data(), buffer.size(), 0);
+    return returnIfNotError(ret);
 }
 
-ssize_t util::Socket::sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept {
-    return ::sendto(socketID_, buffer.data(), buffer.size_bytes(), 0, ai.ai_addr, ai.ai_addrlen);
+std::optional<size_t> util::Socket::recv(std::span<uint8_t> buffer) const noexcept {
+    auto ret = ::recv(socketID_, buffer.data(), buffer.size(), 0);
+    return returnIfNotError(ret);
 }
 
-ssize_t util::Socket::recvFrom(std::span<uint8_t> buffer) const noexcept {
-    return ::recvfrom(socketID_, buffer.data(), buffer.size(), 0, nullptr, nullptr);
+std::optional<size_t> util::Socket::sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept {
+    auto ret = ::sendto(socketID_, buffer.data(), buffer.size_bytes(), 0, ai.ai_addr, ai.ai_addrlen);
+    return returnIfNotError(ret);
+}
+
+std::optional<size_t> util::Socket::recvFrom(std::span<uint8_t> buffer) const noexcept {
+    auto ret = ::recvfrom(socketID_, buffer.data(), buffer.size(), 0, nullptr, nullptr);
+    return returnIfNotError(ret);
 }

--- a/arq-benchmark/util/socket.hpp
+++ b/arq-benchmark/util/socket.hpp
@@ -37,10 +37,10 @@ public:
     // expectedHost is provided, only accept a connection from that host. Throws SocketException on failure.
     [[nodiscard]] Socket accept(std::optional<std::string_view> expectedHost = std::nullopt) const;
 
-    bool send(std::span<const uint8_t> buffer) const noexcept;
-    bool recv(std::span<uint8_t> buffer) const noexcept;
-    ssize_t sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept;
-    ssize_t recvFrom(std::span<uint8_t> buffer) const noexcept;
+    std::optional<size_t> send(std::span<const uint8_t> buffer) const noexcept;
+    std::optional<size_t> recv(std::span<uint8_t> buffer) const noexcept;
+    std::optional<size_t> sendTo(std::span<const uint8_t> buffer, const addrinfo& ai) const noexcept;
+    std::optional<size_t> recvFrom(std::span<uint8_t> buffer) const noexcept;
 private:
     SocketID socketID_;
 };

--- a/arq-benchmark/util/socket.hpp
+++ b/arq-benchmark/util/socket.hpp
@@ -34,8 +34,8 @@ public:
     bool listen(int backlog) const noexcept;
     bool connect(const addrinfo& ai) const noexcept;
     // Accepts a connection, returning a new Socket corresponding to the accepted connection. If
-    // expectedHost is provided, only accept a connection from that host. Throws SocketException on failure.
-    [[nodiscard]] Socket accept(std::optional<std::string_view> expectedHost = std::nullopt) const;
+    // expectedHost is provided, only accept a connection from that host. Returns nullopt on failure.
+    [[nodiscard]] std::optional<Socket> accept(std::optional<std::string_view> expectedHost = std::nullopt) const;
 
     std::optional<size_t> send(std::span<const uint8_t> buffer) const noexcept;
     std::optional<size_t> recv(std::span<uint8_t> buffer) const noexcept;

--- a/arq-benchmark/util/tests/endpoint_test.cpp
+++ b/arq-benchmark/util/tests/endpoint_test.cpp
@@ -43,7 +43,7 @@ static int test_server_tcp(const bool authenticateClient, const bool send) {
     }
 
     if (send) {
-        REQUIRE(endpoint.send(sendBuffer));
+        REQUIRE(endpoint.send(sendBuffer) == sendBuffer.size());
     }
 
     return EXIT_SUCCESS; // Dummy return value for future
@@ -62,7 +62,7 @@ static int test_client_tcp(const bool receive) {
 
     if (receive) {
         std::array<uint8_t, sizeof_sendBuffer> recvBuffer{};
-        REQUIRE(endpoint.recv(recvBuffer));
+        REQUIRE(endpoint.recv(recvBuffer) == sendBuffer.size());
 
         // Check received data is correct
         REQUIRE(recvBuffer == sendBuffer);


### PR DESCRIPTION
Switch various instances of exceptions to use `std::optional` instead to simplify code flow.