### PR TITLE
Clearing up valgrind errors

### DIFF
--- a/arq-benchmark/arq/data_packet.cpp
+++ b/arq-benchmark/arq/data_packet.cpp
@@ -71,12 +71,12 @@ bool arq::DataPacketHeader::deserialise(std::span<const std::byte> buffer) noexc
     return true;
 }
 
-arq::DataPacket::DataPacket()
+arq::DataPacket::DataPacket() : header_{}
 {
     updateDataLength(0);
 }
 
-arq::DataPacket::DataPacket(const DataPacketHeader& hdr)
+arq::DataPacket::DataPacket(const DataPacketHeader& hdr) : header_{}
 {
     updateHeader(hdr);
 }

--- a/arq-benchmark/util/socket.cpp
+++ b/arq-benchmark/util/socket.cpp
@@ -40,7 +40,9 @@ util::Socket::Socket(const addrinfo& ai) : socketID_{createSocket(ai)}
 
 util::Socket::~Socket() noexcept
 {
-    ::close(socketID_);
+    if (socketID_ != SOCKET_ERROR) {
+        ::close(socketID_);
+    }
 }
 
 util::Socket::Socket(Socket&& other) noexcept : socketID_{std::exchange(other.socketID_, SOCKET_ERROR)} {}


### PR DESCRIPTION
Resolves: #22 

This fixes a) the `util::Socket` destructor not checking for invalid file descriptors and b) the `arq::DataPacketHeader` not being initialised in the `arq::DataPacket` constructor.

Running `sudo -E WRAP="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes --verbose" ../test_scripts/run.sh -p "stop-and-wait" -w 4 -t 250 -n 10 -i 100 -l "random 0%" -r -f valgrind.log` now yields:

Server:
```
2025-01-25 09:56:11.061094282 [ INFO  ]: Received ACK for SN 10
2025-01-25 09:56:13.553372443 [ DEBUG ]: Successfully transmitted 5 bytes
2025-01-25 09:56:13.556307943 [ INFO  ]: Transmitter Tx thread exited
2025-01-25 09:56:23.706905093 [WARNING]: Transmitter receive function failed
2025-01-25 09:56:23.710082793 [ INFO  ]: Transmitter ACK thread exited
2025-01-25 09:56:23.713809293 [ DEBUG ]: Transmitter exiting
==14939==
==14939== HEAP SUMMARY:
==14939==     in use at exit: 0 bytes in 0 blocks
==14939==   total heap usage: 3,338 allocs, 3,338 frees, 535,720 bytes allocated
==14939==
==14939== All heap blocks were freed -- no leaks are possible
==14939==
==14939== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```
Client:
```
2025-01-25 09:56:05.649630838 [ INFO  ]: Receiver resequencing thread exited
2025-01-25 09:56:05.647597438 [ DEBUG ]: Received 5 bytes of data
2025-01-25 09:56:05.655232138 [ INFO  ]: Received data packet with length 0 and SN 10
2025-01-25 09:56:05.656992839 [ DEBUG ]: Waiting to add packet to RS
2025-01-25 09:56:05.659415739 [ INFO  ]: Receiver Rx thread exited
==14944==
==14944== HEAP SUMMARY:
==14944==     in use at exit: 0 bytes in 0 blocks
==14944==   total heap usage: 5,793 allocs, 5,793 frees, 1,019,988 bytes allocated
==14944==
==14944== All heap blocks were freed -- no leaks are possible
==14944==
==14944== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```