### PR TITLE
Improve CI reliability

### DIFF
--- a/.github/workflows/cmake-build-debug.yml
+++ b/.github/workflows/cmake-build-debug.yml
@@ -3,7 +3,7 @@ name: Unit tests (debug)
 
 on:
   push:
-    branches: [ "wjg/ci-cleanup" ]
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 
@@ -28,7 +28,6 @@ jobs:
       id: install-boost
       with:
         boost_version: 1.73.0
-        platform_version: 24.04
         
     - name: Install Catch2 v3 from Source
       run: |

--- a/.github/workflows/cmake-build-debug.yml
+++ b/.github/workflows/cmake-build-debug.yml
@@ -3,7 +3,7 @@ name: Unit tests (debug)
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "wjg/ci-cleanup" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/cmake-build-debug.yml
+++ b/.github/workflows/cmake-build-debug.yml
@@ -25,7 +25,12 @@ jobs:
 
     # - name: Install packages
     #   run: sudo apt-get update | sudo apt-get install -y libboost-all-dev
-
+    - name: Install boost
+      uses: MarkusJx/install-boost@v2
+      id: install-boost
+      with:
+        boost_version: 1.73.0
+        
     - name: Install Catch2 v3 from Source
       run: |
         git clone https://github.com/catchorg/Catch2.git
@@ -37,7 +42,9 @@ jobs:
         sudo make install
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOOST_ROOT=${BOOST_ROOT_1_72_0}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-build-debug.yml
+++ b/.github/workflows/cmake-build-debug.yml
@@ -23,13 +23,12 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 --slave /usr/bin/g++ g++ /usr/bin/g++-14 --slave /usr/bin/gcov gcov /usr/bin/gcov-14
         sudo update-alternatives --set gcc /usr/bin/gcc-14
 
-    # - name: Install packages
-    #   run: sudo apt-get update | sudo apt-get install -y libboost-all-dev
     - name: Install boost
       uses: MarkusJx/install-boost@v2
       id: install-boost
       with:
         boost_version: 1.73.0
+        platform_version: 24.04
         
     - name: Install Catch2 v3 from Source
       run: |

--- a/.github/workflows/cmake-build-debug.yml
+++ b/.github/workflows/cmake-build-debug.yml
@@ -23,8 +23,8 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 --slave /usr/bin/g++ g++ /usr/bin/g++-14 --slave /usr/bin/gcov gcov /usr/bin/gcov-14
         sudo update-alternatives --set gcc /usr/bin/gcc-14
 
-    - name: Install packages
-      run: sudo apt-get update | sudo apt-get install -y libboost-all-dev
+    # - name: Install packages
+    #   run: sudo apt-get update | sudo apt-get install -y libboost-all-dev
 
     - name: Install Catch2 v3 from Source
       run: |
@@ -37,7 +37,7 @@ jobs:
         sudo make install
 
     - name: Configure CMake
-      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}} -DBOOST_ROOT=${BOOST_ROOT_1_72_0}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake-build-release.yml
+++ b/.github/workflows/cmake-build-release.yml
@@ -23,8 +23,11 @@ jobs:
         sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-14 100 --slave /usr/bin/g++ g++ /usr/bin/g++-14 --slave /usr/bin/gcov gcov /usr/bin/gcov-14
         sudo update-alternatives --set gcc /usr/bin/gcc-14
 
-    - name: Install packages
-      run: sudo apt-get update | sudo apt-get install -y libboost-all-dev
+    - name: Install boost
+      uses: MarkusJx/install-boost@v2
+      id: install-boost
+      with:
+        boost_version: 1.73.0
 
     - name: Install Catch2 v3 from Source
       run: |
@@ -38,6 +41,8 @@ jobs:
 
     - name: Configure CMake
       run: cmake -B ${{github.workspace}}/build -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}
+      env:
+        BOOST_ROOT: ${{ steps.install-boost.outputs.BOOST_ROOT }}
 
     - name: Build
       run: cmake --build ${{github.workspace}}/build --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
CI frequently fails due to not being able to install boost - let's try with this action to see if it's any better.