### PR TITLE
Clean up RT mutexes

### DIFF
--- a/arq-benchmark/arq/retransmission_buffers/go_back_n_rt.hpp
+++ b/arq-benchmark/arq/retransmission_buffers/go_back_n_rt.hpp
@@ -2,7 +2,6 @@
 #define _ARQ_RT_BUFFERS_GO_BACK_N_HPP_
 
 #include <cstdint>
-#include <mutex>
 #include <optional>
 #include <vector>
 
@@ -30,6 +29,7 @@ private:
 
     const uint16_t windowSize_;
 
+    // WJG: This should be moved out of the class
     struct CircularBuffer {
         // A buffer to hold packets for retransmission
         std::vector<std::optional<TransmitBufferObject>> buffer_;
@@ -38,9 +38,6 @@ private:
         //
         SequenceNumber nextSequenceNumberToAck_;
     } slidingWindow_;
-
-    // Control access to the buffer
-    mutable std::mutex rtBufferMutex_;
 };
 
 } // namespace rt

--- a/arq-benchmark/arq/retransmission_buffers/stop_and_wait_rt.hpp
+++ b/arq-benchmark/arq/retransmission_buffers/stop_and_wait_rt.hpp
@@ -1,7 +1,6 @@
 #ifndef _ARQ_RT_BUFFERS_STOP_AND_WAIT_HPP_
 #define _ARQ_RT_BUFFERS_STOP_AND_WAIT_HPP_
 
-#include <mutex>
 #include <optional>
 
 #include "arq/retransmission_buffer.hpp"
@@ -23,8 +22,6 @@ public:
 private:
     // In Stop and Wait, only one packet is stored for retransmission at a time.
     std::optional<TransmitBufferObject> retransmitPacket_ = std::nullopt;
-    // Control access to the retransmit packet
-    mutable std::mutex rtPacketMutex_;
 };
 
 } // namespace rt


### PR DESCRIPTION
Since shifting to using an ACK queue, the RT buffer mutexes are no longer contested between two threads. This is therefore unnecessary overhead that can be removed.